### PR TITLE
fix ApiSessionRecovering::ResetPasswordService

### DIFF
--- a/app/controllers/api_session_recovering/session_recovering/reset_passwords_controller.rb
+++ b/app/controllers/api_session_recovering/session_recovering/reset_passwords_controller.rb
@@ -16,6 +16,6 @@ class ApiSessionRecovering::SessionRecovering::ResetPasswordsController < ApiSes
   end
 
   def resource_params
-    params.require(:reset_password).permit :token, :old_password, :password, :password_confirmation, :email
+    params.require(:reset_password).permit :token, :password, :password_confirmation, :email
   end
 end

--- a/app/models/api_session_recovering/reset_password.rb
+++ b/app/models/api_session_recovering/reset_password.rb
@@ -1,7 +1,7 @@
 class ApiSessionRecovering::ResetPassword < ApiSessionRecovering::ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :token, presence: true
+  validates :token, presence: true, uniqueness: true
 
   #
   # Reset Password validations attempts


### PR DESCRIPTION
* change order of method calls in `ApiSessionRecovering::ResetPasswordService#save!`
* add `token` uniqueness validation to `ApiSessionRecovering::ResetPassword`
* remove `old_password` param from `ApiSessionRecovering::SessionRecovering::ResetPasswordsController#resource_params`