### PR TITLE
send restore password code with method that was passed in params

### DIFF
--- a/app/models/api_session_recovering/restore_password.rb
+++ b/app/models/api_session_recovering/restore_password.rb
@@ -31,13 +31,13 @@ class ApiSessionRecovering::RestorePassword < ApiSessionRecovering::ApplicationR
   def send_token
     restore_password_methods = ApiSessionRecovering.configuration.restore_password_methods
 
-    ApiSessionRecovering::RestorePasswordMailer.email(self).deliver_later if restore_password_methods.include? :email
+    ApiSessionRecovering::RestorePasswordMailer.email(self).deliver_later if restore_password_methods.include?(:email) && email
 
-    ApiSessionRecovering::TwilioService.new(self).send_sms                if restore_password_methods.include? :sms
+    ApiSessionRecovering::TwilioService.new(self).send_sms                if restore_password_methods.include?(:sms) && phone
   end
 
   def generate_token
-    self.token = SecureRandom.random_number(999999)
+    self.token = rand(100000..999999)
 
     generate_token if ApiSessionRecovering::RestorePassword.exists?(token: self.token, user: self.user)
   end

--- a/lib/generators/templates/api_session_recovering.rb
+++ b/lib/generators/templates/api_session_recovering.rb
@@ -40,7 +40,7 @@ ApiSessionRecovering.configure do |config|
   #
   # => Phone for sending sms (For recovering password via sms uncomment line below)
   #
-  # config.phone_from { '+1**********' }
+  # config.phone_from = '+1**********'
 
   # config.allowed_password_reset_validations_per_day_count = 20
 


### PR DESCRIPTION
From Wiki

> Q: do we send sms or email for password restoring?
> Depending on params U are passing - it can sent email with link or sms with code.

Now it sends both if I set `config.restore_password_methods = [:email, :sms]`:( 
But I need to send only sms if user has typed in phone and mail if he has typed in email. 

